### PR TITLE
all-none checkbox, support not having it

### DIFF
--- a/multiselect.js
+++ b/multiselect.js
@@ -85,10 +85,12 @@ const MultiSelect = (divid, options={}) => {
         searchtext = searchtext.toUpperCase();
 
         // show/hide the all-none checkbox
-        if (searchtext) {
-            $selectall.style.display = 'none';
-        } else {
-            $selectall.style.display = 'block';
+        if ($selectall) {
+            if (searchtext) {
+                $selectall.style.display = 'none';
+            } else {
+                $selectall.style.display = 'block';
+            }
         }
 
         // show/hide each checkbox


### PR DESCRIPTION
Fixes a bug when `allowSelectAll: false` 